### PR TITLE
fix/snowflake-tag-alias

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/fsc-evm.git
-    revision: v3.11.0
+    revision: "fix/snowflake-tagging"

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - git: https://github.com/FlipsideCrypto/fsc-evm.git
-    revision: "fix/snowflake-tagging"
+    revision: v3.11.1


### PR DESCRIPTION
1. Requires `fsc-evm` package update to `v3.11.1` after this [PR](https://github.com/FlipsideCrypto/fsc-evm/pull/75) is merged / released